### PR TITLE
fix libusb discovery on cmake

### DIFF
--- a/perseus-in.h
+++ b/perseus-in.h
@@ -34,7 +34,7 @@
 #include "perseusfx2.h"
 #include "perseus-sdr.h"
 
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 #include <time.h>
 
 typedef struct perseus_input_queue_ds *perseus_input_queue_ptr;

--- a/perseus-sdr.h
+++ b/perseus-sdr.h
@@ -32,7 +32,7 @@
 #if !defined(_WIN32)
 #include <pthread.h>
 #endif
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 #include <time.h>
 
 /** @file */

--- a/perseusfx2.h
+++ b/perseusfx2.h
@@ -29,7 +29,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 
 #define FALSE	0
 #define TRUE	1


### PR DESCRIPTION
should be the same of the include on

perseusfx2.h
perseus-sdr.h
perseus-in.h